### PR TITLE
Use SSE2 in cbits/text.c when possible

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -84,17 +84,30 @@ prop_nonRealZeroNonRealDoubleAsciiDec =
 prop_sizeOfTextUtf8 =
   withTests 999 $
   property $ do
-    a <- forAll (Gen.text (Range.exponential 0 9999) Gen.unicode)
+    a <- forAll (Gen.text (Range.exponential 0 9999) (Gen.choice [Gen.ascii, Gen.unicode]))
     Size.textUtf8 a
       === Char8ByteString.length (Text.encodeUtf8 a)
+
+prop_sizeOfTextASCII =
+  withTests 999 $
+  property $ do
+    a <- forAll (Gen.text (Range.exponential 0 9999) Gen.ascii)
+    Size.textUtf8 a
+      === Char8ByteString.length (Text.encodeUtf8 a)
+
+prop_textASCII =
+  withTests 999 $
+  property $ do
+    a <- forAll (Gen.text (Range.exponential 0 9999) Gen.ascii)
+    Write.writeToByteString (Write.textUtf8 a)
+      === Text.encodeUtf8 a
 
 prop_textUtf8 =
   withTests 999 $
   property $ do
-    a <- forAll (Gen.text (Range.exponential 0 9999) Gen.unicode)
+    a <- forAll (Gen.text (Range.exponential 0 9999) (Gen.choice [Gen.ascii, Gen.unicode]))
     Write.writeToByteString (Write.textUtf8 a)
       === Text.encodeUtf8 a
-
 
 -- * Gens
 -------------------------


### PR DESCRIPTION
SSE2 is available on every x86_64 CPU and has a perfect instruction for UTF16->UTF8 ASCII conversion: https://software.intel.com/sites/landingpage/IntrinsicsGuide/#expand=5608,5656,3357,300,3343,5608,3864,3555,4115&techs=SSE2&text=_mm_packus_epi16

Benchmarks before/after (on a pretty noisy machine):

<img width="1107" alt="Screen Shot 2021-01-01 at 8 13 25 PM" src="https://user-images.githubusercontent.com/222467/103444922-148f9600-4c6e-11eb-98ea-59d4cfd2c8a4.png">
