### PR TITLE
Fix GHC version detection

### DIFF
--- a/library/PtrPoker/UncheckedShifting.hs
+++ b/library/PtrPoker/UncheckedShifting.hs
@@ -60,7 +60,7 @@ shiftr_w w s = fromIntegral $ (`shiftr_w64` s) $ fromIntegral w
 #endif
 
 #if !defined(__HADDOCK__)
-#if __GLASGOW_HASKELL__ >= 920
+#if __GLASGOW_HASKELL__ >= 902
 shiftr_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftRLWord16#` i)
 shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRLWord32#` i)
 #else


### PR DESCRIPTION
Sorry for the repeated PRs. This corrects the version detection according to https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/intro.html#ghc-version-numbering-policy.
- `x.y.z` becomes `x0y`
- `x.yy.z` becomes `xyy`