### PR TITLE
Support text 2

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - master
       - dev
+  pull_request: {}
 
 jobs:
 
@@ -17,7 +18,9 @@ jobs:
 
     strategy:
       matrix:
-        ghc: ['8.4.2', '9.0.1']
+        ghc: ['8.4', '9.0']
+        text_constraint: ['text == 1.*', 'text == 2.*']
+      fail-fast: false
 
     runs-on: ubuntu-latest
 
@@ -26,11 +29,15 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup Haskell
-        uses: haskell/actions/setup@v1.2.1
+        uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: 3.4
       
+      - run: |
+          echo "constraints: ${{ matrix.text_constraint }}" >> cabal.project
+          echo "allow-newer:" >> cabal.project
+          echo "  *:*" >> cabal.project
       - run: cabal v2-update --enable-tests --enable-benchmarks
       - run: cabal v2-freeze --enable-tests --enable-benchmarks
 

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/library/PtrPoker/ByteString.hs
+++ b/library/PtrPoker/ByteString.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module PtrPoker.ByteString where
 
 import Data.ByteString
@@ -7,6 +8,7 @@ import Data.ByteString.Builder.Prim
 import qualified Data.ByteString.Builder.Scientific as ScientificBuilder
 import Data.ByteString.Internal
 import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.Text.Encoding as TextEncoding
 import qualified PtrPoker.Ffi as Ffi
 import PtrPoker.Prelude hiding (empty)
 import qualified PtrPoker.Text as Text
@@ -40,9 +42,13 @@ unsafeCreateDownToN allocSize populate =
 
 {-# INLINEABLE textUtf8 #-}
 textUtf8 :: Text -> ByteString
+#if MIN_VERSION_text(2,0,0)
+textUtf8 t = TextEncoding.encodeUtf8 t
+#else
 textUtf8 = Text.destruct $ \arr off len ->
   if len == 0
     then empty
     else unsafeCreateUptoN (len * 3) $ \ptr -> do
       postPtr <- inline Ffi.encodeText ptr arr (fromIntegral off) (fromIntegral len)
       return (minusPtr postPtr ptr)
+#endif

--- a/library/PtrPoker/ByteString.hs
+++ b/library/PtrPoker/ByteString.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 module PtrPoker.ByteString where
 
 import Data.ByteString

--- a/library/PtrPoker/Poke.hs
+++ b/library/PtrPoker/Poke.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE CPP #-}
 module PtrPoker.Poke where
 
+import qualified Data.Text.Array as TextArray
+import qualified Data.Text.Internal as TextInternal
 import qualified PtrPoker.Ffi as Ffi
 import qualified PtrPoker.IO.ByteString as ByteStringIO
 import qualified PtrPoker.IO.Prim as PrimIO
@@ -140,8 +143,15 @@ bInt64 = bWord64 . fromIntegral
 -- Encode Text in UTF8.
 {-# INLINE textUtf8 #-}
 textUtf8 :: Text -> Poke
+#if MIN_VERSION_text(2,0,0)
+textUtf8 (TextInternal.Text arr off len) =
+  Poke (\p -> do
+    stToIO $ TextArray.copyToPointer arr off p len
+    pure (plusPtr p len))
+#else
 textUtf8 = Text.destruct $ \arr off len ->
   Poke (\p -> Ffi.encodeText p arr (fromIntegral off) (fromIntegral len))
+#endif
 
 -- * ASCII integers
 

--- a/library/PtrPoker/Poke.hs
+++ b/library/PtrPoker/Poke.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 module PtrPoker.Poke where
 
 import qualified Data.Text.Array as TextArray

--- a/library/PtrPoker/Size.hs
+++ b/library/PtrPoker/Size.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -- |
 -- Functions that compute the required allocation size by value.
 module PtrPoker.Size where
@@ -202,9 +203,13 @@ int64AsciiDec x =
 {-# INLINE textUtf8 #-}
 textUtf8 :: Text -> Int
 textUtf8 = Text.destruct $ \arr off len ->
+#if MIN_VERSION_text(2,0,0)
+  len
+#else
   Ffi.countTextAllocationSize
     arr
     (fromIntegral off)
     (fromIntegral len)
     & unsafeDupablePerformIO
     & fromIntegral
+#endif

--- a/library/PtrPoker/Size.hs
+++ b/library/PtrPoker/Size.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+
 -- |
 -- Functions that compute the required allocation size by value.
 module PtrPoker.Size where
@@ -202,10 +203,10 @@ int64AsciiDec x =
 -- in UTF8.
 {-# INLINE textUtf8 #-}
 textUtf8 :: Text -> Int
-textUtf8 = Text.destruct $ \arr off len ->
 #if MIN_VERSION_text(2,0,0)
-  len
+textUtf8 = Text.destruct $ \_arr _off len -> len
 #else
+textUtf8 = Text.destruct $ \arr off len ->
   Ffi.countTextAllocationSize
     arr
     (fromIntegral off)

--- a/ptr-poker.cabal
+++ b/ptr-poker.cabal
@@ -1,5 +1,5 @@
 name: ptr-poker
-version: 0.1.2.3
+version: 0.2
 synopsis: Pointer poking action construction and composition toolkit
 homepage: https://github.com/nikita-volkov/ptr-poker
 bug-reports: https://github.com/nikita-volkov/ptr-poker/issues
@@ -40,7 +40,7 @@ library
     base >=4.11 && <5,
     bytestring >=0.10 && <0.12,
     scientific >=0.3.6.2 && <0.4,
-    text >=1 && <2
+    text >=1 && <3
 
 test-suite test
   type: exitcode-stdio-1.0


### PR DESCRIPTION
All the `textUtf8` functions are now pretty trivial.

I've temporarily added `allow-newer` to the CI script, otherwise `rebase` and probably some more packages refuse to build.